### PR TITLE
Add support for MacOS.

### DIFF
--- a/qt-linux/ts3soundboard.pri
+++ b/qt-linux/ts3soundboard.pri
@@ -33,7 +33,8 @@ HEADERS += ../src/ExpandableSection.h \
     ../src/SpeechBubble.h \
     ../src/UpdateChecker.h \
     ../src/updater_qt.h \
-    ../src/config_qt.h
+    ../src/config_qt.h \
+    ../src/TalkStateManager.h
 SOURCES += ../src/about_qt.cpp \
     ../src/buildinfo.c \
     ../src/CmdQueue.cpp \
@@ -43,7 +44,7 @@ SOURCES += ../src/about_qt.cpp \
     ../src/main.cpp \
     ../src/HighResClock.cpp \
     ../src/inputfileffmpeg.cpp \
-    ../src/plugin.c \
+    ../src/plugin.cpp \
     ../src/SampleBuffer.cpp \
     ../src/SampleProducerThread.cpp \
     ../src/samples.cpp \
@@ -55,7 +56,8 @@ SOURCES += ../src/about_qt.cpp \
     ../src/SpeechBubble.cpp \
     ../src/ts3log.cpp \
     ../src/UpdateChecker.cpp \
-    ../src/updater_qt.cpp
+    ../src/updater_qt.cpp \
+    ../src/TalkStateManager.cpp
 FORMS += ../src/config_qt.ui \
     ../src/about_qt.ui \
     ../src/soundsettings_qt.ui \

--- a/qt-mac/ts3soundboard_mac.pro
+++ b/qt-mac/ts3soundboard_mac.pro
@@ -1,0 +1,29 @@
+# Qt project file for linux builds
+
+QT_CONFIG -= no-pkg-config
+
+CONFIG += c++11 plugin link_pkgconfig
+linux-g++-32:ARCHID = 32
+linux-g++-64:ARCHID = 64
+CONFIG(debug, release|debug):BUILDTYPE = "debug"
+CONFIG(release, release|debug):BUILDTYPE = "release"
+TEMPLATE = lib
+TARGET = rp_soundboard
+DESTDIR = ../bin/$${BUILDTYPE}_lin
+
+QT += core network widgets gui
+
+DEFINES += LINUX QT_DLL QT_WIDGETS_LIB
+CONFIG(debug, release|debug):DEFINES += _DEBUG
+CONFIG(release, release|debug):DEFINES += NDEBUG
+
+INCLUDEPATH += ../include
+
+LIBS += "-L/Applications/TeamSpeak 3 Client.app/Contents/SharedSupport/update.app/Contents/Frameworks/"
+
+PKGCONFIG += libavcodec libavutil libavformat libswresample
+
+QMAKE_POST_LINK += "cp $${DESTDIR}/lib$${TARGET}.dylib ~/Library/Application\ Support/TeamSpeak\ 3/plugins"
+
+
+include(../qt-linux/ts3soundboard.pri)

--- a/src/SampleVisualizerThread.h
+++ b/src/SampleVisualizerThread.h
@@ -13,6 +13,7 @@
 #include <thread>
 #include <mutex>
 #include <vector>
+#include <string>
 
 #include "SampleBuffer.h"
 

--- a/src/samples.cpp
+++ b/src/samples.cpp
@@ -18,7 +18,7 @@
 #include <queue>
 #include <vector>
 #include <cassert>
-
+#include <math.h>
 
 #define USE_SSE2
 //#define MEASURE_PERFORMANCE


### PR DESCRIPTION
This supports TeamSpeak 3.1.4 Stable using Qt 5.6.1 on MacOS. Tested on MacOS Sierra 10.12.4.

Changes made:

 - qt-linux/ts3soundboard.pri: Added missing files TalkStateManager.{h,cpp} and fixed the file extension of plugin.c to plugin.cpp.
 - qt-mac/ts3soundboard_mac.pro: New file. Based on ts3soundboard_linux.pro but with significant changes/improvements. Future work might be able to unify ts3soundboard_linux.pro and ts3soundboard_mac.pro.
 - src/SampleVisualizerThread.h: Some compilers might tolerate not having the `<string>` header in a file that uses `std::string`, but clang treats this as an error, so the include is needed. This will not affect behavior or cause compilation failures on other compilers, as technically adding this header is more correct.
 - src/samples.cpp: Some compilers might tolerate not having the `<math.h>` header in a file that uses `pow`, but clang treats this as an error, so the include is needed. This will not affect behavior or cause compilation failures on other compilers, as technically adding this header is more correct.

The following build toolchain was used:

From Homebrew (package manager):
 - ffmpeg 3.3
 - Qt 5.6.1 headers/libs

From Apple:
 - XCode 8.3.2 (clang-802.0.42)

Screenshot: 

![asdf](https://cloud.githubusercontent.com/assets/322644/25784847/fdeb9226-3341-11e7-8dce-7cbf63866ff5.png)
