### PR TITLE
Changes update source to use HTTPS

### DIFF
--- a/src/UpdateChecker.cpp
+++ b/src/UpdateChecker.cpp
@@ -37,9 +37,9 @@
 #include "ConfigModel.h"
 
 #if defined(_WIN32)
-#define CHECK_URL "http://mgraefe.de/rpsb/version/version.xml"
+#define CHECK_URL "https://mgraefe.de/rpsb/version/version.xml"
 #elif defined(LINUX)
-#define CHECK_URL "http://mgraefe.de/rpsb/version/version_linux_amd64.xml"
+#define CHECK_URL "https://mgraefe.de/rpsb/version/version_linux_amd64.xml"
 #endif
 
 


### PR DESCRIPTION
Hi, I noticed your update site still works over HTTPS, this pull request is to change the update urls to use the HTTPS version. This is needed because using an unsecured HTTP connection might be intercepted and an attacker can modify the following xml:
```
<latestDownload>
      <url>http://www.mediafire.com/file/9r4lz2bp51xt6w4/rp_soundboard_1733.ts3_plugin</url>
</latestDownload>
```
to point to a malicious ts3 plugin. HTTPS will prevent this.

Cheers,
Joshua Green