### PR TITLE
split volume slider into remote and local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ release/plugins/
 build/
 build32/
 build64/
+.vscode/
 
 # we don't commit pre-compiled linux libraries since it's way easier to compile
 # ffmpeg on linux compared to windows

--- a/src/ConfigModel.cpp
+++ b/src/ConfigModel.cpp
@@ -25,7 +25,8 @@ ConfigModel::ConfigModel()
 {
 	m_rows.fill(2);
 	m_cols.fill(5);
-	m_volume = 80;
+	m_volumeLocal = 80;
+	m_volumeRemote = 80;
 	m_playbackLocal = true;
 	m_muteMyselfDuringPb = false;
 	m_windowWidth = 600;
@@ -64,7 +65,9 @@ void ConfigModel::readConfig(const QString &file)
 		m_rows[i] = settings.value(i == 0 ? QString("num_rows") : QString("num_rows%1").arg(i + 1), i == 0 ? 2 : m_rows[0]).toInt();
 		m_cols[i] = settings.value(i == 0 ? QString("num_cols") : QString("num_cols%1").arg(i + 1), i == 0 ? 5 : m_cols[0]).toInt();
 	}
-	m_volume = settings.value("volume", 50).toInt();
+	int volume_old = settings.value("volume", 50).toInt();
+	m_volumeLocal = settings.value("volumeLocal", volume_old).toInt();
+	m_volumeLocal = settings.value("volumeRemote", volume_old).toInt();
 	m_playbackLocal = settings.value("playback_local", true).toBool();
 	m_muteMyselfDuringPb = settings.value("mute_myself_during_pb", false).toBool();
 	m_windowWidth = settings.value("window_width", 600).toInt();
@@ -93,7 +96,8 @@ void ConfigModel::writeConfig(const QString &file)
     QSettings settings(path, QSettings::IniFormat);
 
     settings.setValue("config_build", buildinfo_getBuildNumber());
-    settings.setValue("volume", m_volume);
+    settings.setValue("volumeLocal", m_volumeLocal);
+    settings.setValue("volumeRemote", m_volumeRemote);
     settings.setValue("playback_local", m_playbackLocal);
     settings.setValue("mute_myself_during_pb", m_muteMyselfDuringPb);
     settings.setValue("window_width", m_windowWidth);
@@ -282,12 +286,20 @@ void ConfigModel::setCols( int n )
 //---------------------------------------------------------------
 // Purpose: 
 //---------------------------------------------------------------
-void ConfigModel::setVolume( int val )
+void ConfigModel::setVolumeLocal( int val )
 {
-	m_volume = val;
-	notify(NOTIFY_SET_VOLUME, val);
+	m_volumeLocal = val;
+	notify(NOTIFY_SET_VOLUME_LOCAL, val);
 }
 
+//---------------------------------------------------------------
+// Purpose: 
+//---------------------------------------------------------------
+void ConfigModel::setVolumeRemote( int val )
+{
+	m_volumeRemote = val;
+	notify(NOTIFY_SET_VOLUME_REMOTE, val);
+}
 
 //---------------------------------------------------------------
 // Purpose: 
@@ -459,7 +471,8 @@ void ConfigModel::notifyAllEvents()
 		notify(NOTIFY_SET_SOUND, i);
 	notify(NOTIFY_SET_COLS, getCols());
 	notify(NOTIFY_SET_ROWS, getRows());
-	notify(NOTIFY_SET_VOLUME, m_volume);
+	notify(NOTIFY_SET_VOLUME_LOCAL, m_volumeLocal);
+	notify(NOTIFY_SET_VOLUME_REMOTE, m_volumeRemote);
 	notify(NOTIFY_SET_PLAYBACK_LOCAL, m_playbackLocal);
 	notify(NOTIFY_SET_MUTE_MYSELF_DURING_PB, m_muteMyselfDuringPb);
 	notify(NOTIFY_SET_WINDOW_SIZE, 0);

--- a/src/ConfigModel.h
+++ b/src/ConfigModel.h
@@ -27,7 +27,8 @@ public:
 		NOTIFY_SET_SOUND,
 		NOTIFY_SET_ROWS,
 		NOTIFY_SET_COLS,
-		NOTIFY_SET_VOLUME,
+		NOTIFY_SET_VOLUME_LOCAL,
+		NOTIFY_SET_VOLUME_REMOTE,
 		NOTIFY_SET_PLAYBACK_LOCAL,
 		NOTIFY_SET_MUTE_MYSELF_DURING_PB,
 		NOTIFY_SET_WINDOW_SIZE,
@@ -69,8 +70,11 @@ public:
 	inline int getCols() const { return m_cols[m_activeConfig]; }
 	void setCols(int n);
 
-	inline int getVolume() const { return m_volume; }
-	void setVolume(int val);
+	inline int getVolumeLocal() const { return m_volumeLocal; }
+	void setVolumeLocal(int val);
+
+	inline int getVolumeRemote() const { return m_volumeRemote; }
+	void setVolumeRemote(int val);
 
 	inline bool getPlaybackLocal() const { return m_playbackLocal; }
 	void setPlaybackLocal(bool val);
@@ -121,7 +125,8 @@ private:
 
     std::array<int, NUM_CONFIGS> m_rows;
 	std::array<int, NUM_CONFIGS> m_cols;
-	int m_volume;
+	int m_volumeLocal;
+	int m_volumeRemote;
 	bool m_playbackLocal;
 	bool m_muteMyselfDuringPb;
 	int m_windowWidth;

--- a/src/SoundInfo.h
+++ b/src/SoundInfo.h
@@ -12,6 +12,7 @@
 
 #include <QSettings>
 #include <QColor>
+#include <stdexcept>
 
 class SoundInfo
 {

--- a/src/TalkStateManager.h
+++ b/src/TalkStateManager.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include <QObject>
+#include <stdexcept>
 #include "common.h"
 
 class TalkStateManager : public QObject 

--- a/src/config_qt.h
+++ b/src/config_qt.h
@@ -61,7 +61,8 @@ protected:
 private slots:
 	void onClickedPlay();
 	void onClickedStop();
-	void onUpdateVolume(int val);
+	void onUpdateVolumeLocal(int val);
+	void onUpdateVolumeRemote(int val);
 	void onUpdateMuteLocally(bool val);
 	void onUpdateCols(int val);
 	void onUpdateRows(int val);
@@ -83,7 +84,8 @@ private slots:
 	void onButtonPausePressed();
 	void onButtonDroppedOnButton(SoundButton *button);
 	void onFilterEditTextChanged(const QString &filter);
-	void onVolumeSliderContextMenu(const QPoint &point);
+	void onVolumeSliderContextMenuLocal(const QPoint &point);
+	void onVolumeSliderContextMenuRemote(const QPoint &point);
 
     void onSetConfig();
     void onConfigHotkey();

--- a/src/config_qt.ui
+++ b/src/config_qt.ui
@@ -215,12 +215,12 @@
           <item>
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Volume:</string>
+             <string>Volume Remote:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QSlider" name="sl_volume">
+           <widget class="QSlider" name="sl_volumeRemote">
             <property name="maximum">
              <number>100</number>
             </property>
@@ -241,7 +241,34 @@
          </layout>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_5"/>
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Volume Local:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSlider" name="sl_volumeLocal">
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="pageStep">
+             <number>10</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::NoTicks</enum>
+            </property>
+            <property name="tickInterval">
+             <number>0</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,8 +63,11 @@ void ModelObserver_Prog::notify(ConfigModel &model, ConfigModel::notifications_e
 {
 	switch(what)
 	{
-	case ConfigModel::NOTIFY_SET_VOLUME:
-		sampler->setVolume(data);
+	case ConfigModel::NOTIFY_SET_VOLUME_LOCAL:
+		sampler->setVolumeLocal(data);
+		break;
+	case ConfigModel::NOTIFY_SET_VOLUME_REMOTE:
+		sampler->setVolumeRemote(data);
 		break;
 	case ConfigModel::NOTIFY_SET_PLAYBACK_LOCAL:
 		sampler->setLocalPlayback(model.getPlaybackLocal());
@@ -385,11 +388,13 @@ CAPI void sb_onHotkeyPressed(const char * keyword)
 	}
 	else if (strcmp(keyword, HOTKEY_VOLUME_INCREASE) == 0)
 	{
-		configModel->setVolume(std::min(configModel->getVolume() + 20, 100));
+		configModel->setVolumeRemote(std::min(configModel->getVolumeRemote() + 20, 100));
+		configModel->setVolumeLocal(std::min(configModel->getVolumeLocal() + 20, 100));
 	}
 	else if (strcmp(keyword, HOTKEY_VOLUME_DECREASE) == 0)
 	{
-		configModel->setVolume(std::max(configModel->getVolume() - 20, 0));
+		configModel->setVolumeRemote(std::max(configModel->getVolumeRemote() - 20, 0));
+		configModel->setVolumeLocal(std::min(configModel->getVolumeLocal() - 20, 0));
 	}
 }
 

--- a/src/samples.h
+++ b/src/samples.h
@@ -46,7 +46,8 @@ public:
 	bool playFile(const SoundInfo &sound);
 	bool playPreview(const SoundInfo &sound);
 	void stopPlayback();
-	void setVolume(int vol);
+	void setVolumeLocal(int vol);
+	void setVolumeRemote(int vol);
 	void setLocalPlayback(bool enabled);
 	void setMuteMyself(bool enabled);
 	void pausePlayback();
@@ -79,7 +80,8 @@ private:
 	int m_volumeDivider;
 	float m_volumeFactor;
 	static const int volumeScaleExp = 12;
-	double m_globalDbSetting;
+	double m_globalDbSettingLocal;
+	double m_globalDbSettingRemote;
 	double m_soundDbSetting;
 	std::mutex m_mutex;
 	std::atomic<state_e> m_state;


### PR DESCRIPTION
Hi, I had the same issue as https://github.com/MGraefe/RP-Soundboard/issues/99, so I implemented this as a solution.
This should also cover the feature request https://github.com/MGraefe/RP-Soundboard/issues/69.

Unfortunately, I couldn't test it with TeamSpeak because it couldn't install my compiled .dll.
I also compiled this project from master, but TeamSpeak couldn't install it either.
Maybe I am using a wrong compiler?
I am using: MSVC 19.35.32215.0  (Compiler of Visual Studio Code 2022)